### PR TITLE
Updated jda to be most stable release to fix compile issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ application {
 }
 
 version '1.0'
-def jdaVersion = '4.ALPHA.0_48'
+def jdaVersion = '3.8.3_460'
+//Switched to latest stable release, see https://github.com/DV8FromTheWorld/JDA/releases
 
 sourceCompatibility = targetCompatibility = 1.8
 


### PR DESCRIPTION
Gradle will now compile, and you just need the token.txt file to be able to run it:

Proof of successful compile, and run task failure:
```
> Task :run FAILED
Exception in thread "main" java.io.FileNotFoundException: token.txt (The system cannot find the file specified)
	at java.io.FileInputStream.open0(Native Method)
```